### PR TITLE
Use local success constant to avoid error if Command::SUCCESS does no…

### DIFF
--- a/src/Command/MigrationsGenerateCommand.php
+++ b/src/Command/MigrationsGenerateCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class MigrationsGenerateCommand extends AbstractMigrationCommand
 {
+    private const COMMAND_SUCCESS = 0;
     protected static $defaultName = 'clickhouse:migrations:generate';
 
     protected function configure()
@@ -23,7 +24,7 @@ class MigrationsGenerateCommand extends AbstractMigrationCommand
         $path = $generator->generateMigration();
         $this->io->write(sprintf('Success generate new Migration: %s', $path));
 
-        return Command::SUCCESS;
+        return self::COMMAND_SUCCESS;
     }
 
 }


### PR DESCRIPTION
Hi. That's problem when in main project does not exist 'SUCCESS' const inside Symfony's Command class
In that case I got error "
In MigrationsCommand.php line 83:
                                       Undefined class constant 'SUCCESS'  "
I propose to replace this const to local const